### PR TITLE
Adding command-line options to canopy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+_build/
+disk/
+
+key_gen.ml
+main.ml
+static1.ml
+static1.mli
+
+Makefile
+log
+
+canopy.x[el]
+canopy.x[el].in
+canopy_libvirt.xml
+main.native
+mir-canopy

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ article content
 
 If you don't respect this syntax, then the article won't show up in the resulting website.
 
+## Updating the blog content
+In order to keep your blog up-to-date, you need to tell the unikernel that something was pushed in the git repository.
+Canopy use an URL defined in canopy_config.ml, who trigger a pull when it receive a HTTP request.
+If you are using github, you can then simply set a webhook for push events on your blog's repository, and then wherever you push new content, your blog state will be updated.
+
+
  [decompress]: <https://github.com/oklm-wsh/Decompress>
  [mirage]: <http://mirage.io/>
  [irmin]: <https://github.com/mirage/irmin>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Canopy is written in OCaml using MirageOS and [Irmin][irmin], but it is currentl
 
 ## Getting started
 
-You will need the latest version of `OCaml`, `opam` and `mirage` before starting. To setup a mirage environment, please refer to the mirage website.
+You will need at least `OCaml 4.02.3`, `opam 1.2` and `mirage 2.7.0` before starting. To setup a mirage environment, please refer to the mirage website.
 You'll also need `bower` and `less-css` if you want to compile and retrieve everything related to the blog-styling (not needed to just test things out).
 
 Checkout Canopy repository, then go inside:
@@ -62,5 +62,3 @@ If you don't respect this syntax, then the article won't show up in the resultin
  [decompress]: <https://github.com/oklm-wsh/Decompress>
  [mirage]: <http://mirage.io/>
  [irmin]: <https://github.com/mirage/irmin>
-
-

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -7,7 +7,7 @@ type t = {
 
 let config = {
   remote_uri = "https://github.com/Engil/__blog.git";
-  index_page = "Index.md";
+  index_page = "Index";
   port = 8080;
   push_hook_path = "push";
 }

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -8,8 +8,8 @@ type t = {
 
 let config () = {
   remote_uri = Key_gen.remote ();
-  index_page = "Index";
+  index_page = Key_gen.index ();
   name = "Canopy";
-  port = 8080;
+  port = Key_gen.port ();
   push_hook_path = "push";
 }

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -1,5 +1,6 @@
 type t = {
   remote_uri : string;
+  name : string;
   index_page : string;
   port : int;
   push_hook_path: string;
@@ -8,6 +9,7 @@ type t = {
 let config = {
   remote_uri = "https://github.com/Engil/__blog.git";
   index_page = "Index";
+  name = "Canopy";
   port = 8080;
   push_hook_path = "push";
 }

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -6,8 +6,8 @@ type t = {
   push_hook_path: string;
 }
 
-let config = {
-  remote_uri = "https://github.com/Engil/__blog.git";
+let config () = {
+  remote_uri = Key_gen.remote ();
   index_page = "Index";
   name = "Canopy";
   port = 8080;

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -68,7 +68,7 @@ module Main  (C: CONSOLE) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (S:Cohtt
       Lwt_io.printlf "Repository pulled" in
     pull () >>= fun _ ->
     let rec dispatcher uri =
-      let s_uri = Re_str.split (Re_str.regexp "/") uri in
+      let s_uri = Re_str.split (Re_str.regexp "/") (Uri.pct_decode uri) in
       match s_uri with
       | "static"::_ ->
         begin

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -55,7 +55,8 @@ module Main  (C: CONSOLE) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (S:Cohtt
       new_task () >>= fun t ->
       Store.list (t "Reading posts") [] >>= fun keys ->
       let index = Canopy_config.config.index_page in
-      let body = Canopy_templates.template_main ~index ~content ~title ~keys in
+      let name = Canopy_config.config.name in
+      let body = Canopy_templates.template_main ~index ~content ~name ~title ~keys in
       S.respond_string ~status ~body () in
 
     new_task () >>= fun t ->

--- a/canopy_templates.ml
+++ b/canopy_templates.ml
@@ -9,7 +9,7 @@ let template_links keys =
       "<li><a href='/%s'><span>%s</span></a></li>" link link in
   List.fold_left (fun str link -> str ^ (format_link link)) "" paths
 
-let template_main ~index ~content ~title ~keys =
+let template_main ~index ~name ~content ~title ~keys =
     let links = template_links keys in
     Printf.sprintf "
 <html>
@@ -32,7 +32,7 @@ let template_main ~index ~content ~title ~keys =
         <span class='icon-bar'></span>
         <span class='icon-bar'></span>
       </button>
-        <a class='navbar-brand' href='/%s'>Canopy blog engine</a>
+        <a class='navbar-brand' href='/%s'>%s</a>
       </div>
       <div class='collapse navbar-collapse collapse'>
         <ul class='nav navbar-nav navbar-right'>
@@ -47,7 +47,7 @@ let template_main ~index ~content ~title ~keys =
   </div>
 </main>
 </body>
-" title index links content
+" title index name links content
 
 
 let template_article article =

--- a/canopy_types.ml
+++ b/canopy_types.ml
@@ -18,7 +18,7 @@ let meta_assoc str =
 let article_of_string uri str =
   try
     let r_meta = Re_str.regexp "---" in
-    let s_str = Re_str.split r_meta str in
+    let s_str = Re_str.bounded_split r_meta str 2 in
     match s_str with
     | [meta; content] ->
       let content =

--- a/config.ml
+++ b/config.ml
@@ -8,14 +8,23 @@ let remote_k =
   let doc = Key.Arg.info ~doc:"Remote repository to fetch content." ["r"; "remote"] in
   Key.(create "remote" Arg.(opt string "https://github.com/Engil/__blog.git" doc))
 
+let index_k =
+  let doc = Key.Arg.info ~doc:"Index file name in remote." ["i"; "index"] in
+  Key.(create "index" Arg.(opt string "Index" doc))
+
+let port_k =
+  let doc = Key.Arg.info ~doc:"Socket port." ["p"; "port"] in
+  Key.(create "port" Arg.(opt int 8080 doc))
+
 let main =
   let libraries = ["irmin.git"; "cow"; "mirage-http"; "irmin.mirage";"tls.mirage";] in
   let libraries = if get_mode () = `Xen then libraries else "irmin.unix" :: libraries in
   foreign
     ~libraries
     ~deps:[abstract nocrypto]
-    ~packages:["irmin"; "mirage-http"; "mirage-flow";"tls";"cow";
-               "mirage-types-lwt"; "channel"; "git"; "mirage-git"; "git-unix";"re";"cohttp"]
+    ~keys:Key.([abstract remote_k; abstract index_k; abstract port_k])
+    ~packages:["irmin"; "mirage-http"; "mirage-flow"; "tls"; "cow";
+               "mirage-types-lwt"; "channel"; "git"; "mirage-git"; "git-unix"; "re"; "cohttp"]
     "Canopy_main.Main" (console @-> resolver @-> conduit @-> http @-> kv_ro @-> job)
 
 let () =

--- a/config.ml
+++ b/config.ml
@@ -4,6 +4,10 @@ let stack console = socket_stackv4 console [Ipaddr.V4.any]
 
 let disk = crunch "./disk"
 
+let remote_k =
+  let doc = Key.Arg.info ~doc:"Remote repository to fetch content." ["r"; "remote"] in
+  Key.(create "remote" Arg.(opt string "https://github.com/Engil/__blog.git" doc))
+
 let main =
   let libraries = ["irmin.git"; "cow"; "mirage-http"; "irmin.mirage";"tls.mirage";] in
   let libraries = if get_mode () = `Xen then libraries else "irmin.unix" :: libraries in

--- a/style.sh
+++ b/style.sh
@@ -1,3 +1,3 @@
-mkdir disk
+mkdir -p disk
 bower install
 lessc -x less/style.less disk/static/css/style.css


### PR DESCRIPTION
make Canopy understand command-line options to make easily configurable:
- remote git repository; 
- index page; 
- socket port.
