### PR TITLE
display published information as well; also redefine pretty

### DIFF
--- a/canopy_article.ml
+++ b/canopy_article.ml
@@ -26,8 +26,11 @@ let of_string meta uri created updated content =
 
 let to_tyxml article =
   let author = "Written by " ^ article.author in
-  let date = ptime_to_pretty_date article.updated in
-  let updated = "Last updated: " ^ date in
+  let created = ptime_to_pretty_date article.created in
+  let updated = ptime_to_pretty_date article.updated in
+  let updated = String.concat " "
+      [ "Published:" ; created ; "(last updated:" ; updated ^ ")" ]
+  in
   let tags = Canopy_templates.taglist article.tags in
   [div ~a:[a_class ["post"]] [
 	 h2 [pcdata article.title];

--- a/canopy_utils.ml
+++ b/canopy_utils.ml
@@ -31,8 +31,8 @@ let resize len l =
 let (++) = List.append
 
 let ptime_to_pretty_date t =
-  Ptime.to_date t |> fun (d, m, y) ->
-    Printf.sprintf "%d/%d/%d" d m y
+  Ptime.to_date t |> fun (y, m, d) ->
+    Printf.sprintf "%02d.%02d.%04d" d m y
 
 module KeyHashtbl = struct
     module KeyHash = struct


### PR DESCRIPTION
`Ptime.to_date` returns `(y, m, d)`, not `(d, m, y)`.  not sure whether `/` or `.` as date separator is "prettier"... this patch adds the published and last updated timestamp on each article
