### PR TITLE
issue #25 HTTP last modified header

### DIFF
--- a/canopy_dispatch.ml
+++ b/canopy_dispatch.ml
@@ -3,7 +3,8 @@ open Lwt.Infix
 type store_ops = {
   subkeys : string list -> string list list Lwt.t ;
   value : string list -> string option Lwt.t ;
-  update : unit -> string list Lwt.t
+  update : unit -> string list Lwt.t ;
+  last_commit : unit -> Ptime.t Lwt.t ;
 }
 
 module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
@@ -23,68 +24,87 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
     let headers = Cohttp.Header.init_with "location" (Uri.to_string uri) in
     S.respond ~headers ~status:`Moved_permanently ~body:`Empty ()
 
-  let rec dispatcher config headers console disk store atom cache uri =
+  let rec dispatcher config headers console disk store atom cache uri etag updated =
     let open Canopy_utils in
-    let respond_html ~headers ~status ~content ~title =
+    let respond_not_found () =
+      S.respond_string ~headers ~status:`Not_found ~body:"Not found" ()
+    in
+    let respond_if_modified ~headers ~body ~updated =
+      match etag with
+      | Some tg when Ptime.to_rfc3339 updated = tg ->
+        S.respond ~headers ~status:`Not_modified ~body:`Empty ()
+      | _ ->
+        S.respond_string ~headers ~status:`OK ~body ()
+    in
+    let respond_html ~headers ~content ~title ~updated =
       store.subkeys [] >>= fun keys ->
       let body = Canopy_templates.main ~config ~content ~title ~keys in
-      let headers = Cohttp.Header.add headers "Content-Type" "text/html; charset=UTF-8" in
-      S.respond_string ~headers ~status ~body ()
+      let headers = html_headers headers updated in
+      respond_if_modified ~headers ~body ~updated
     and respond_update = function
       | [] -> S.respond_string ~headers ~status:`OK ~body:"" ()
       | errors ->
-	let body = List.fold_left (fun a b -> a ^ "\n" ^ b) "" errors in
+        let body = List.fold_left (fun a b -> a ^ "\n" ^ b) "" errors in
         S.respond_string ~headers ~status:`Bad_request ~body ()
     in
     match Re_str.split (Re_str.regexp "/") (Uri.pct_decode uri) with
-    | [] -> dispatcher config headers console disk store atom cache config.Canopy_config.index_page
+    | [] ->
+      dispatcher config headers console disk store atom cache config.Canopy_config.index_page etag updated
     | "static"::_ ->
       begin
         read_fs disk uri >>= function
         | None -> S.respond_string ~headers ~status:`Not_found ~body:"Not found" ()
-        | Some body -> 
-          let headers = Cohttp.Header.add headers "Content-Type" (Magic_mime.lookup uri) in
-          S.respond_string ~headers ~status:`OK ~body ()
+        | Some body ->
+          let headers = static_headers headers uri updated in
+          respond_if_modified ~headers ~body ~updated
       end
     | "atom" :: [] ->
       atom () >>= fun body ->
-      let headers =
-        Cohttp.Header.add headers
-          "Content-Type" "application/atom+xml; charset=UTF-8"
-      in
-      S.respond_string ~headers ~status:`OK ~body ()
+      store.last_commit () >>= fun updated ->
+      let headers = atom_headers headers updated in
+      respond_if_modified ~headers ~body ~updated
     | uri::[] when uri = config.Canopy_config.push_hook_path ->
       store.update () >>= fun l ->
       respond_update l
-    | "tags"::tagname::_ ->
+    | "tags"::tagname::_ -> (
       let aux _ v l =
         if Canopy_content.find_tag tagname v then (v::l) else l
       in
-      let content =
-	KeyHashtbl.fold aux cache []
-          |> List.sort Canopy_content.compare
-	  |> List.map Canopy_content.to_tyxml_listing_entry
-          |> Canopy_templates.listing
-      in
-      respond_html ~headers ~status:`OK ~title:config.Canopy_config.blog_name ~content
-    | key ->
+      let sorted = KeyHashtbl.fold aux cache [] |> List.sort Canopy_content.compare in
+      match sorted with
+      | [] -> respond_not_found ()
+      | a::_ ->
+        let updated = Canopy_content.date a in
+        let content = sorted
+                      |> List.map Canopy_content.to_tyxml_listing_entry
+                      |> Canopy_templates.listing
+        in
+        respond_html ~headers ~title:config.Canopy_config.blog_name ~content ~updated
+      )
+     | key ->
       begin
         match KeyHashtbl.find_opt cache key with
-        | None ->
+        | None -> (
           store.subkeys key >>= fun keys ->
           if (List.length keys) = 0 then
-            S.respond_string ~headers ~status:`Not_found ~body:"Not found" ()
+            respond_not_found ()
           else
-            let articles = List.map (KeyHashtbl.find_opt cache) keys in
-            let content =
-	      list_reduce_opt articles
-                |> List.sort Canopy_content.compare
-		|> List.map Canopy_content.to_tyxml_listing_entry
-                |> Canopy_templates.listing in
-            respond_html ~headers ~status:`OK ~title:config.Canopy_config.blog_name ~content
+            let articles = List.map (KeyHashtbl.find_opt cache) keys |> list_reduce_opt in
+            match articles with
+            | [] -> respond_not_found ()
+            | a::_ -> (
+                let sorted = List.sort Canopy_content.compare articles in
+                let updated = Canopy_content.date a in
+                let content = sorted
+                              |> List.map Canopy_content.to_tyxml_listing_entry
+                              |> Canopy_templates.listing
+                in
+                respond_html ~headers ~title:config.Canopy_config.blog_name ~content ~updated
+              ))
         | Some article ->
           let title, content = Canopy_content.to_tyxml article in
-          respond_html ~headers ~status:`OK ~title ~content
+          let updated = Canopy_content.date article in
+          respond_html ~headers ~title ~content ~updated
       end
 
     let create console dispatch =
@@ -99,11 +119,12 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE) (Disk: V1_LWT.KV_RO)
              let uri = fn req in
              C.log_s console (Printf.sprintf "redirecting to %s" (Uri.to_string uri)) >>= fun () ->
              moved_permanently uri)
-        | `Dispatch (config, headers, disk, store, atom, content) ->
+        | `Dispatch (config, headers, disk, store, atom, content, time) ->
           (fun _ request _ ->
              let uri = Cohttp.Request.uri request in
+             let etag = Cohttp.Header.get Cohttp.Request.(request.headers) "if-none-match" in
              C.log_s console (Printf.sprintf "request %s" (Uri.to_string uri)) >>= fun () ->
-             dispatcher config headers console disk store atom content (Uri.path uri))
+             dispatcher config headers console disk store atom content (Uri.path uri) etag time)
       in
       S.make ~callback ~conn_closed ()
 

--- a/canopy_utils.ml
+++ b/canopy_utils.ml
@@ -35,16 +35,31 @@ let ptime_to_pretty_date t =
     Printf.sprintf "%04d-%02d-%02d" y m d
 
 module KeyHashtbl = struct
-    module KeyHash = struct
-	type t = string list
-	let equal = (=)
-	let hash = Hashtbl.hash
-      end
+  module KeyHash = struct
+    type t = string list
+    let equal = (=)
+    let hash = Hashtbl.hash
+  end
 
-    module H = Hashtbl.Make(KeyHash)
-    include H
+  module H = Hashtbl.Make(KeyHash)
+  include H
 
-    let find_opt t k =
-      try Some (H.find t k) with
-      | Not_found -> None
+  let find_opt t k =
+    try Some (H.find t k) with
+    | Not_found -> None
 end
+
+let add_etag_header time headers =
+  Cohttp.Header.add headers "Etag" (Ptime.to_rfc3339 time)
+
+let html_headers headers time =
+  Cohttp.Header.add headers "Content-Type" "text/html; charset=UTF-8"
+  |> add_etag_header time
+
+let atom_headers headers time =
+  Cohttp.Header.add headers "Content-Type" "application/atom+xml; charset=UTF-8"
+  |> add_etag_header time
+
+let static_headers headers uri time =
+  Cohttp.Header.add headers "Content-Type" (Magic_mime.lookup uri)
+  |> add_etag_header time


### PR DESCRIPTION
I have added an Etag header in the HTTP response.

The Etag is a hash of :

the unikernel startup time () for static files
the article date for a specific article
the most recent article date, for the tags or for a group of articles
the store latest commit for the Atom feed
If the Etag form the request match the one we are calculating for the response, we return a 304
Otherwise we respond with a new Etag header.
