### PR TITLE
fix atom feed by passing in the ref, not the dereferenced thing

### DIFF
--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -44,7 +44,7 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
     let open Canopy_config in
     let config = config () in
     let update_atom, atom =
-      Canopy_syndic.atom config Store.last_commit_date !cache
+      Canopy_syndic.atom config Store.last_commit_date cache
     in
     let store_ops = {
       Canopy_dispatch.subkeys = Store.get_subkeys ;

--- a/canopy_syndic.ml
+++ b/canopy_syndic.ml
@@ -6,7 +6,7 @@ open Canopy_config
 let atom config last_commit_date content_cache =
   let cache = ref None in
   let update_atom () =
-    let l = KeyMap.fold (fun _ x acc -> x :: acc) content_cache []
+    let l = KeyMap.fold (fun _ x acc -> x :: acc) !content_cache []
             |> List.sort Canopy_content.compare
             |> resize 10 in
     let entries = List.map Canopy_content.to_atom l in


### PR DESCRIPTION
...my intuition in here https://github.com/Engil/Canopy/pull/37#discussion_r61597699 was correct... (the atom feed was empty on hannes.nqsb.io after I deployed)...
