### PR TITLE
fix timestamps (but stays on Irmin 0.10.1)

### DIFF
--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -118,9 +118,9 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
       date_updated_created key >>= fun (updated, created) ->
       let uri = List.fold_left (fun s a -> s ^ "/" ^ a) "" key in
       match of_string ~uri ~content ~created ~updated with
-      | Ok article -> (
-          article_map := KeyMap.add key article !article_map;
-          Lwt.return acc)
+      | Ok article ->
+        article_map := KeyMap.add key article !article_map;
+        Lwt.return acc
       | Error error ->
         let error_msg = Printf.sprintf "Error while parsing %s: %s" (key_to_path key) error in
         Lwt.return (error_msg::acc)

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -112,20 +112,19 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
 
   let fill_cache article_map =
     let open Canopy_content in
-    let key_to_path key = List.fold_left (fun a b -> a ^ "/" ^ b) "" key in
     let fold_fn key value acc =
       value () >>= fun content ->
       date_updated_created key >>= fun (updated, created) ->
-      let uri = List.fold_left (fun s a -> s ^ "/" ^ a) "" key in
+      let uri = String.concat "/" key in
       match of_string ~uri ~content ~created ~updated with
       | Ok article ->
         article_map := KeyMap.add key article !article_map;
         Lwt.return acc
       | Error error ->
-        let error_msg = Printf.sprintf "Error while parsing %s: %s" (key_to_path key) error in
+        let error_msg = Printf.sprintf "Error while parsing %s: %s" uri error in
         Lwt.return (error_msg::acc)
       | Unknown ->
-        let error_msg = Printf.sprintf "%s : Unknown content type" (key_to_path key) in
+        let error_msg = Printf.sprintf "%s : Unknown content type" uri in
         Lwt.return (error_msg::acc)
     in
     new_task () >>= fun t ->

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -114,7 +114,7 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
     let open Canopy_content in
     let key_to_path key = List.fold_left (fun a b -> a ^ "/" ^ b) "" key in
     let fold_fn key value acc =
-      value >>= fun content ->
+      value () >>= fun content ->
       date_updated_created key >>= fun (updated, created) ->
       let uri = List.fold_left (fun s a -> s ^ "/" ^ a) "" key in
       match of_string ~uri ~content ~created ~updated with

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -100,13 +100,10 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
     Store.head_exn (t "Finding head") >>= fun head ->
     last_updated_commit_id head key >>= fun updated_commit_id ->
     created_commit_id head key >>= fun created_commit_id ->
-    Store.Repo.task_of_commit_id repo updated_commit_id >>= fun task ->
-    let date = Irmin.Task.date task |> Int64.to_float in
-    let updated_date = Ptime.of_float_s date in
-    Store.Repo.task_of_commit_id repo created_commit_id >>= fun task ->
-    let date = Irmin.Task.date task |> Int64.to_float in
-    let created_date = Ptime.of_float_s date in
-    match updated_date, created_date with
+    let to_ptime task = Irmin.Task.date task |> Int64.to_float |> Ptime.of_float_s in
+    Store.Repo.task_of_commit_id repo updated_commit_id >>= fun updated ->
+    Store.Repo.task_of_commit_id repo created_commit_id >>= fun created ->
+    match to_ptime updated, to_ptime created with
     | Some a, Some b -> Lwt.return (a, b)
     | _ -> raise (Invalid_argument "date_updated_last")
 

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -69,8 +69,10 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
                 let to_visit = if ((List.mem pred visited) = false) then pred::to_visit else to_visit in
                 to_visit
               | q -> print_endline "weird"; List.append (List.rev q) to_visit)
-          in aux commit visited to_visit
-        | None -> Lwt.return last_commit in
+          in
+          aux commit visited to_visit
+        | None -> Lwt.return last_commit
+    in
     aux commit [] [commit]
 
   let last_updated_commit_id commit key =
@@ -91,8 +93,8 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
         Lwt.return (res, matching)
       | None -> Lwt.return (commit_id, true) in
     Store.history (t "Reading history") >>= fun history ->
-    Topological.fold aux history (Lwt.return (commit, false))
-    >>= fun (c, _) -> Lwt.return c
+    Topological.fold aux history (Lwt.return (commit, false)) >|= fun (c, _) ->
+    c
 
   let date_updated_created key =
     new_task () >>= fun t  ->

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -53,24 +53,24 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
       match to_visit with
       | [] -> Lwt.return last_commit
       | commit::to_visit ->
-   Store.of_commit_id (Irmin.Task.none) commit repo >>= fun store ->
-   Store.read (store ()) keys >>= fun readed_file ->
-   let visited = commit::visited in
-   match readed_file with
-   | Some _ ->
-      let to_visit =
-        ( match Store.History.pred history commit with
-    | [] -> to_visit
-    | pred::pred2::[] ->
-       let to_visit = if ((List.mem pred visited) = false) then pred::to_visit else to_visit in
-       let to_visit = if ((List.mem pred2 visited) = false) then pred2::to_visit else to_visit in
-       to_visit
-    | pred::[] ->
-       let to_visit = if ((List.mem pred visited) = false) then pred::to_visit else to_visit in
-       to_visit
-    | q -> print_endline "weird"; List.append (List.rev q) to_visit)
-      in aux commit visited to_visit
-   | None -> Lwt.return last_commit in
+        Store.of_commit_id (Irmin.Task.none) commit repo >>= fun store ->
+        Store.read (store ()) keys >>= fun readed_file ->
+        let visited = commit::visited in
+        match readed_file with
+        | Some _ ->
+          let to_visit =
+            ( match Store.History.pred history commit with
+              | [] -> to_visit
+              | pred::pred2::[] ->
+                let to_visit = if ((List.mem pred visited) = false) then pred::to_visit else to_visit in
+                let to_visit = if ((List.mem pred2 visited) = false) then pred2::to_visit else to_visit in
+                to_visit
+              | pred::[] ->
+                let to_visit = if ((List.mem pred visited) = false) then pred::to_visit else to_visit in
+                to_visit
+              | q -> print_endline "weird"; List.append (List.rev q) to_visit)
+          in aux commit visited to_visit
+        | None -> Lwt.return last_commit in
     aux commit [] [commit]
 
   let last_updated_commit_id commit key =


### PR DESCRIPTION
is on top of #43, cleaner code which also works with 0.10.1 (maybe too much work with 0.11.0 where the `Topographical.fold` seems to be sorted by date)
