### PR TITLE
feed issues #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Checkout Canopy repository, then go inside:
 mirage configure --unix
 # Compile Canopy
 make
+# Generate a UUID for the Atom feed (only do this the first time)
+uuidtrip -r > myuuid.txt
 # Run it
-./mir-canopy -r https://github.com/Engil/Canopy-documentation.git -i Welcome -p 8080
+./mir-canopy -r https://github.com/Engil/Canopy-documentation.git -i Welcome -p 8080 -u "`cat myuuid.txt`"
 ```
 
 A server will be launched using the specified URL as the git remote, `Index` as the default page rendered on the blog (it must exist within the repository) and `8080` is the listening port.

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -5,6 +5,8 @@ type t = {
   port : int;
   push_hook_path: string;
   tls_port : int option;
+  uuid : string;
+  root : string;
 }
 
 let config () = {
@@ -14,4 +16,6 @@ let config () = {
   port = Key_gen.port ();
   push_hook_path = Key_gen.push_hook ();
   tls_port = Key_gen.tls_port ();
+  uuid = Key_gen.uuid ();
+  root = Key_gen.root ();
 }

--- a/canopy_syndic.ml
+++ b/canopy_syndic.ml
@@ -13,10 +13,10 @@ let atom config last_commit_date content_cache =
     let ns_prefix _ = Some "" in
     last_commit_date () >|= fun updated ->
     Syndic.Atom.feed
-      ~id:(Uri.of_string config.blog_name)
+      ~id:(Uri.of_string ("urn:uuid:" ^ config.uuid))
       ~title:(Syndic.Atom.Text config.blog_name : Syndic.Atom.text_construct)
       ~updated
-      ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string "/atom")]
+      ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string (config.root ^ "/atom"))]
       entries
     |> fun feed -> Syndic.Atom.to_xml feed
     |> fun x -> Syndic.XML.to_string ~ns_prefix x

--- a/config.ml
+++ b/config.ml
@@ -42,7 +42,7 @@ let config_shell = impl @@ object
     method module_name = "Functoria_runtime"
     method name = "shell_config"
     method ty = shellconfig
-end
+  end
 
 (* disk device *)
 
@@ -52,6 +52,14 @@ let disk =
   fat_ro "./disk"
 
 (* Command-line options *)
+
+let root_k =
+  let doc = Key.Arg.info ~doc:"Blog URL" ["root"] in
+  Key.(create "root" Arg.(opt string "http://localhost" doc))
+
+let uuid_k =
+  let doc = Key.Arg.info ~doc:"UUID used as atom feed id." ["u"; "uuid"] in
+  Key.(create "uuid" Arg.(required string doc))
 
 let index_k =
   let doc = Key.Arg.info ~doc:"Index file name in remote." ["i"; "index"] in
@@ -89,6 +97,7 @@ let libraries = [
     "tls.mirage";
     "tyxml";
     "syndic";
+    "uuidm";
   ]
 
 let packages = [
@@ -107,6 +116,7 @@ let packages = [
     "cohttp";
     "syndic";
     "magic-mime";
+    "uuidm";
   ]
 
 
@@ -126,6 +136,8 @@ let () =
       abstract remote_k;
       abstract tls_port_k;
       abstract no_assets_k;
+      abstract uuid_k;
+      abstract root_k;
     ])
   in
   register "canopy" [


### PR DESCRIPTION
Fix atom feed validation errors

I used an urn:uuid: scheme for the feed id (provided on the command line via the --uuid flag) and entries id.

I've also added a new command line flag, --root, to provide the blog URL (some feed errors were due to URLs being relative)
