### PR TITLE
fix all 4.03 warnings in the codebase

### DIFF
--- a/canopy_article.ml
+++ b/canopy_article.ml
@@ -15,7 +15,7 @@ type t = {
 let of_string meta uri created updated content =
   try
     let split_tags = Re_str.split (Re_str.regexp ",") in
-    let content = Omd.of_string content |> Omd.to_html in
+    let content = Omd.to_html (Omd.of_string content) in
     let author = List.assoc "author" meta in
     let title = List.assoc "title" meta in
     let tags = assoc_opt "tags" meta |> map_opt split_tags [] |> List.map String.trim in
@@ -84,7 +84,7 @@ let to_atom ({ title; author; abstract; uri; created; updated; tags; content; } 
       (fun x -> Syndic.Atom.category ~scheme:(Uri.of_string (root ^ "/tags/" ^ x)) x)
       tags
   in
-  let generate_id { created; uri; _ } =
+  let generate_id { created; _ } =
     let open Uuidm in
     let stamp = Ptime.to_rfc3339 created in
     let uuid = Canopy_config.((config ()).uuid) in

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -75,19 +75,19 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
     | _ -> raise (Invalid_argument "date_updated_last")
 
   let fill_cache article_map =
-    let open Canopy_content in
+    let module C = Canopy_content in
     let fold_fn key value acc =
       value () >>= fun content ->
       date_updated_created key >>= fun (updated, created) ->
       let uri = String.concat "/" key in
-      match of_string ~uri ~content ~created ~updated with
-      | Ok article ->
+      match C.of_string ~uri ~content ~created ~updated with
+      | C.Ok article ->
         article_map := KeyMap.add key article !article_map;
         Lwt.return acc
-      | Error error ->
+      | C.Error error ->
         let error_msg = Printf.sprintf "Error while parsing %s: %s" uri error in
         Lwt.return (error_msg::acc)
-      | Unknown ->
+      | C.Unknown ->
         let error_msg = Printf.sprintf "%s : Unknown content type" uri in
         Lwt.return (error_msg::acc)
     in


### PR DESCRIPTION
- warning 45 was raised in canopy_store.ml as a local open introduces
  Ok/Error, which now shadow the standard `result` type
  constructors. The `let open .. in` is turned into a `let module
  C = .. in` to work around this. See also
  [MPR#7386](http://caml.inria.fr/mantis/view.php?id=7386).
- an unused identifier warning was fixed
- `Omd.of_string content |> Omd.to_html` warns as `to_html` has
  a ton of implicit parameters that are "implicitly omitted" in
  this higher-order style. I'm not very happy about it, but the
  dumb rewrite into `Omd.to_html (Omd.of_string content)` avoids
  the warning.

This commit is in fact incomplete as there are instances of warning 42
(which warns on _any_ use of type-based disambiguation) left in the
codebase. Canopy itself cannot do anything about these instances of
disambiguation, they come from the fact that Syndic, in version 1.5.1,
has two distinct Text constructors in Syndic.Atom -- I guess this was
not the case before.

I fixed it locally by editing the Makefile to add -42 to warn(..), but
I don't know how to change it in config.ml. Any help?
