### PR TITLE
accept urls of the form git://foo.git#branch to specify a branch name

### DIFF
--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -1,5 +1,6 @@
 type t = {
   remote_uri : string;
+  remote_branch : string option;
   blog_name : string;
   index_page : string;
   port : int;
@@ -9,8 +10,20 @@ type t = {
   root : string;
 }
 
+let decompose_git_url url =
+    match String.rindex url '#' with
+    | exception Not_found -> (url, None)
+    | i ->
+      let remote_url = String.sub url 0 i in
+      let branch = String.sub url (i + 1) (String.length url - i - 1) in
+      (remote_url, Some branch)
+
+let remote_uri () = fst (decompose_git_url (Key_gen.remote ()))
+let remote_branch () = snd (decompose_git_url (Key_gen.remote ()))
+
 let config () = {
-  remote_uri = Key_gen.remote ();
+  remote_uri = remote_uri ();
+  remote_branch = remote_branch ();
   index_page = Key_gen.index ();
   blog_name = Key_gen.name ();
   port = Key_gen.port ();

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -15,7 +15,12 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
   let task s = Irmin.Task.create ~date:0L ~owner:"Server" s
   let config = Canopy_config.config ()
   let repo _ = Store.Repo.create store_config
-  let new_task _ = repo () >>= Store.master task
+
+  let new_task _ =
+    match config.remote_branch with
+    | None -> repo () >>= Store.master task
+    | Some branch -> repo () >>= Store.of_branch_id task branch
+
   let upstream = Irmin.remote_uri config.remote_uri
 
   let get_subkeys key =

--- a/config.ml
+++ b/config.ml
@@ -82,7 +82,10 @@ let push_hook_k =
   Key.(create "push_hook" Arg.(opt string "push" doc))
 
 let remote_k =
-  let doc = Key.Arg.info ~doc:"Remote repository to fetch content." ["r"; "remote"] in
+  let doc = Key.Arg.info ~doc:"Remote repository to fetch content.\
+                             \ Use suffix #foo to specify a branch 'foo':\
+                             \ https://github.com/user/blog.git#content"
+      ["r"; "remote"] in
   Key.(create "remote" Arg.(opt string "https://github.com/Engil/__blog.git" doc))
 
 (* Dependencies *)


### PR DESCRIPTION
Another option would be to accept a separate option (-b branch)
instead of the url suffix, or to accept both and fail if there is an
ambiguity. The suffix feels like a standard convention among git
users.

fixes #68 
