### PR TITLE
fix created/update dates from branches

### DIFF
--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -51,8 +51,8 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
          Lwt.return (C.log console msg))
 
   let created_updated_ids commit key =
+    new_task () >>= fun t ->
     repo () >>= fun repo ->
-    Store.master task repo >>= fun t  ->
     Store.history (t "Reading history") >>= fun history ->
     let aux commit_id acc =
       Store.of_commit_id (Irmin.Task.none) commit_id repo >>= fun store ->


### PR DESCRIPTION
This fixes a bug that only occurs when a branch is specified -- using #68.

> In f4b6454476b2d193f31bcc0b29ba15e2a882f68b we introduced support for
> fetching the blog content from a branch, but the code to compute
> creation and update dates for individual post is still assuming that
> the 'master' branch should be used by default; as a result, blog posts
> would appear in the Atom feed in the wrong order. This seems to be due
> to a discrepancy in the code style that does not occur anywhere else
> in the codebase. The discrepancy is now fixed and the Atom feed is as
> expected.
> 
> Note that the Atom feed is still ordered by creation date instead of
> last-update date, which may or may not correspond to authors'
> expectation. Either are fine for my current use-case.
