### PR TITLE
Store assets and config in git remote; use Logs library

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -12,6 +12,7 @@ PKG tyxml
 PKG mirage-console
 PKG syndic
 PKG ptime
+PKG uuidm
 
 S .
 B _build

--- a/.merlin
+++ b/.merlin
@@ -13,6 +13,7 @@ PKG mirage-console
 PKG syndic
 PKG ptime
 PKG uuidm
+PKG logs
 
 S .
 B _build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-FROM ocaml/dev:release-ubuntu-14.04_ocaml-4.02.3
+FROM ocaml/opam:debian-stable_ocaml-4.03.0
 MAINTAINER canopy
 ENV OPAMYES 1
 RUN sudo apt-get update
 RUN sudo apt-get -yy install npm
-RUN sudo npm install -g less browserify
-RUN cd /home/opam/opam-repository; git pull && opam update; cd -
-RUN opam upgrade
-RUN opam update
 RUN sudo ln -s `which nodejs` /usr/bin/node
+RUN sudo npm install -g less browserify
+RUN cd /home/opam/opam-repository && git pull && opam update
+RUN opam remote add mirage-dev git://github.com/mirage/mirage-dev.git
+RUN opam update -u
 ADD package.json README.md config.ml /src/
 WORKDIR /src
 ADD tls /src/tls
 RUN sudo chown -R opam:opam /src; sudo chmod -R 700 /src
 ENV TMP /tmp
+RUN opam install -y -j2 mirage
 RUN opam config exec -- mirage configure --no-assets-compilation
 COPY . /src
 ADD assets /src/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,17 @@ RUN sudo apt-get -yy install npm
 RUN sudo ln -s `which nodejs` /usr/bin/node
 RUN sudo npm install -g less browserify
 RUN cd /home/opam/opam-repository && git pull && opam update
-RUN opam remote add mirage-dev git://github.com/mirage/mirage-dev.git
-RUN opam update -u
 ADD package.json README.md config.ml /src/
 WORKDIR /src
 ADD tls /src/tls
 RUN sudo chown -R opam:opam /src; sudo chmod -R 700 /src
 ENV TMP /tmp
 RUN opam install -y -j2 mirage
-RUN opam config exec -- mirage configure --no-assets-compilation
 COPY . /src
 ADD assets /src/assets
 RUN sudo chown -R opam:opam /src; sudo chmod -R 700 /src
-RUN opam config exec -- mirage configure --no-opam --no-depext
+RUN opam config exec -- mirage configure
 RUN opam config exec -- make
+RUN sudo mkdir /tmp/assets ; sudo chown opam:opam /tmp/assets ; ./populate.sh /tmp/assets
 EXPOSE 8080
 ENTRYPOINT ["opam", "config", "exec", "--", "./mir-canopy"]

--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ Checkout Canopy repository, then go inside:
 mirage configure --unix
 # Compile Canopy
 make
-# Generate a UUID for the Atom feed (only do this the first time)
-uuidtrip -r > myuuid.txt
 # Run it
-./mir-canopy -r https://github.com/Engil/Canopy-documentation.git -i Welcome -p 8080 -u "`cat myuuid.txt`"
+./mir-canopy
 ```
 
 A server will be launched using the specified URL as the git remote, `Index` as the default page rendered on the blog (it must exist within the repository) and `8080` is the listening port.
@@ -52,14 +50,41 @@ You can see more options by running `./mir-canopy --help`.
 To prepare your own data repository, you have to use `npm`, `less-css` and `browserify` if you want to compile and retrieve everything related to the blog-styling. The `mirage configure` step takes care of fetching and recompiling all assets. If none of the mentioned programs were to be found, the configure step will use the tarball found in the `assets` directory, containing already compiled assets.
 
 ```
-mkdir /tmp/data
-cd /tmp/data && git init .
-# Either populate data using npm, browserify, etc.
-./populate.sh /tmp/data
-# OR use pregenerated tarball
-cd /tmp/data && tar xf assets/assets_generated.tar.gz
-cd /tmp/data && mv disk/static .
+# OR start with git clone git://github.com/Engil/__blog.git ;)
+mkdir canopy-data
+cd canopy-data
+git init .
+# Populate data using npm, browserify, etc.
+if [ -x `which npm` ] ; then
+  ./populate.sh /tmp/data
+else
+  # OR use pregenerated tarball
+  cd /tmp/data && tar xf assets/assets_generated.tar.gz
+  cd /tmp/data && mv disk/static .
+fi;
+
+git add static
+
+# Generate a UUID for the Atom feed
+uuidtrip -r > .config/uuid
+# Add blog name (defaults to "Canopy")
+echo "My blog" > .config/blog_name
+git add .config
+
+git commit -m initial
+
+# configure git remote and push
+git remote add origin git@github.com/me/__blog.git
+git push origin master
 ```
+
+You can run Canopy with your own data repository:
+
+```
+./mir-canopy -r git://github.com/me/__blog.git
+```
+
+You can use git branches for drafting changes: `./mir-canopy -r git://github.com/me/__blog.git#dev`.
 
 ### Compiling and running on Xen
 
@@ -119,7 +144,9 @@ Each directories will contains more pages, but that will be classified under a c
 For example, a `posts/hello-word.md` file will be a new blog post under the `Posts` category.
 You can use it to emulate some sort of tag, like for example having an `OCaml` directory regrouping all you writing in everyone's favorite language. :-)
 
-The file syntax is just plain markdown, everything should be supported out-the-box (depending on the [`ocaml-omd`](https://github.com/ocaml/omd) markdown implementation), with a little bit of extra informations absolutely needed at the top of each files.
+Static assets (not processed) can be added into "static" subdir, configuration values below ".config".
+
+The file syntax of articles is just plain markdown, everything should be supported out-the-box (depending on the [`ocaml-omd`](https://github.com/ocaml/omd) markdown implementation), with a little bit of extra informations absolutely needed at the top of each files.
 
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ header (containing `max-age=31536000`).
 ### Compiling and running Canopy
 
 You will need at least `OCaml 4.02.3`, `opam 1.2` and `mirage 2.7.0` before starting. To setup a mirage environment, please refer to the mirage website.
-You'll also need `npm`, `less-css` and `browserify` if you want to compile and retrieve everything related to the blog-styling. The `mirage configure` step takes care of fetching and recompiling all assets. If none of the mentioned programs were to be found, the configure step will use the tarball found in the `assets` directory, containing already compiled assets.
 
 Checkout Canopy repository, then go inside:
 
@@ -49,6 +48,18 @@ uuidtrip -r > myuuid.txt
 
 A server will be launched using the specified URL as the git remote, `Index` as the default page rendered on the blog (it must exist within the repository) and `8080` is the listening port.
 You can see more options by running `./mir-canopy --help`.
+
+To prepare your own data repository, you have to use `npm`, `less-css` and `browserify` if you want to compile and retrieve everything related to the blog-styling. The `mirage configure` step takes care of fetching and recompiling all assets. If none of the mentioned programs were to be found, the configure step will use the tarball found in the `assets` directory, containing already compiled assets.
+
+```
+mkdir /tmp/data
+cd /tmp/data && git init .
+# Either populate data using npm, browserify, etc.
+./populate.sh /tmp/data
+# OR use pregenerated tarball
+cd /tmp/data && tar xf assets/assets_generated.tar.gz
+cd /tmp/data && mv disk/static .
+```
 
 ### Compiling and running on Xen
 

--- a/canopy_article.ml
+++ b/canopy_article.ml
@@ -71,13 +71,13 @@ let to_tyxml_tags tags =
       h2 [pcdata "Tags"];
       div ~a:[a_class ["list-group listing"]] [html]]]
 
-let to_atom ({ title; author; abstract; uri; created; updated; tags; content; } as article) =
+let to_atom cache ({ title; author; abstract; uri; created; updated; tags; content; } as article) =
   let text x : Syndic.Atom.text_construct = Syndic.Atom.Text x in
   let summary = match abstract with
     | Some x -> Some (text x)
     | None -> None
   in
-  let root = Canopy_config.((config ()).root) 
+  let root = Canopy_config.root cache
   in
   let categories =
     List.map
@@ -87,7 +87,7 @@ let to_atom ({ title; author; abstract; uri; created; updated; tags; content; } 
   let generate_id { created; _ } =
     let open Uuidm in
     let stamp = Ptime.to_rfc3339 created in
-    let uuid = Canopy_config.((config ()).uuid) in
+    let uuid = Canopy_config.uuid cache in
     let entry_id = to_string (v5 (create (`V5 (ns_dns, stamp))) uuid) in
     Printf.sprintf "urn:uuid:%s" entry_id
     |> Uri.of_string

--- a/canopy_article.ml
+++ b/canopy_article.ml
@@ -10,9 +10,10 @@ type t = {
   created: Ptime.t;
   updated: Ptime.t;
   tags: string list;
+  uuid: string;
 }
 
-let of_string meta uri created updated content =
+let of_string base_uuid meta uri created updated content =
   try
     let split_tags = Re_str.split (Re_str.regexp ",") in
     let content = Omd.to_html (Omd.of_string content) in
@@ -20,7 +21,13 @@ let of_string meta uri created updated content =
     let title = List.assoc "title" meta in
     let tags = assoc_opt "tags" meta |> map_opt split_tags [] |> List.map String.trim in
     let abstract = assoc_opt "abstract" meta in
-    Some {title; content; author; uri; abstract; created; updated; tags}
+    let uuid =
+      let open Uuidm in
+      let stamp = Ptime.to_rfc3339 created in
+      let entry_id = to_string (v5 (create (`V5 (ns_dns, stamp))) base_uuid) in
+      Printf.sprintf "urn:uuid:%s" entry_id
+    in
+    Some {title; content; author; uri; abstract; created; updated; tags; uuid}
   with
   | _ -> None
 
@@ -71,7 +78,7 @@ let to_tyxml_tags tags =
       h2 [pcdata "Tags"];
       div ~a:[a_class ["list-group listing"]] [html]]]
 
-let to_atom cache ({ title; author; abstract; uri; created; updated; tags; content; } as article) =
+let to_atom cache ({ title; author; abstract; uri; created; updated; tags; content; uuid}) =
   let text x : Syndic.Atom.text_construct = Syndic.Atom.Text x in
   let summary = match abstract with
     | Some x -> Some (text x)
@@ -84,16 +91,8 @@ let to_atom cache ({ title; author; abstract; uri; created; updated; tags; conte
       (fun x -> Syndic.Atom.category ~scheme:(Uri.of_string (root ^ "/tags/" ^ x)) x)
       tags
   in
-  let generate_id { created; _ } =
-    let open Uuidm in
-    let stamp = Ptime.to_rfc3339 created in
-    let uuid = Canopy_config.uuid cache in
-    let entry_id = to_string (v5 (create (`V5 (ns_dns, stamp))) uuid) in
-    Printf.sprintf "urn:uuid:%s" entry_id
-    |> Uri.of_string
-  in
   Syndic.Atom.entry
-    ~id:(generate_id article)
+    ~id:(Uri.of_string uuid)
     ~content:(Syndic.Atom.Html (None, content))
     ~authors:(Syndic.Atom.author author, [])
     ~title:(text title)

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -12,6 +12,9 @@ let decompose_git_url url =
 
 let remote_uri () = fst (decompose_git_url (Key_gen.remote ()))
 let remote_branch () = snd (decompose_git_url (Key_gen.remote ()))
+let port () = Key_gen.port ()
+let tls_port () = Key_gen.tls_port ()
+let push_hook_path () = Key_gen.push_hook ()
 
 let index_page cache =
   match KeyMap.find_config_opt cache [".config";"index_page"] with
@@ -32,15 +35,3 @@ let root cache =
   match KeyMap.find_config_opt cache [".config";"root"] with
     None -> "http://localhost"
   | Some r -> r
-
-let port cache =
-  match KeyMap.find_config_opt cache [".config";"port"] with
-    None -> 8080
-  | Some s -> String.trim s |> int_of_string
-
-let tls_port cache =
-  match KeyMap.find_config_opt cache [".config";"tls_port"] with
-    None -> None
-  | Some s -> Some (String.trim s |> int_of_string)
-        
-let push_hook_path () = Key_gen.push_hook ()

--- a/canopy_config.ml
+++ b/canopy_config.ml
@@ -1,14 +1,12 @@
 open Canopy_utils
 
-exception Required_config of string
-
 let decompose_git_url url =
-    match String.rindex url '#' with
-    | exception Not_found -> (url, None)
-    | i ->
-      let remote_url = String.sub url 0 i in
-      let branch = String.sub url (i + 1) (String.length url - i - 1) in
-      (remote_url, Some branch)
+  match String.rindex url '#' with
+  | exception Not_found -> (url, None)
+  | i ->
+    let remote_url = String.sub url 0 i in
+    let branch = String.sub url (i + 1) (String.length url - i - 1) in
+    (remote_url, Some branch)
 
 let remote_uri () = fst (decompose_git_url (Key_gen.remote ()))
 let remote_branch () = snd (decompose_git_url (Key_gen.remote ()))
@@ -16,22 +14,19 @@ let port () = Key_gen.port ()
 let tls_port () = Key_gen.tls_port ()
 let push_hook_path () = Key_gen.push_hook ()
 
+let entry name = [ ".config" ; name ]
+
 let index_page cache =
-  match KeyMap.find_config_opt cache [".config";"index_page"] with
-    None -> "Index"
-  | Some p -> p
+  match KeyMap.find_opt cache @@ entry "index_page" with
+  | Some (`Config p) -> p
+  | _ -> "Index"
 
 let blog_name cache =
-  match KeyMap.find_config_opt cache [".config";"blog_name"] with
-    None -> "Canopy"
-  | Some n -> n
-
-let uuid cache =
-  match KeyMap.find_config_opt cache [".config";"uuid"] with
-    None -> raise (Required_config "uuid")
-  | Some u -> u
+  match KeyMap.find_opt cache @@ entry "blog_name" with
+  | Some (`Config n) -> n
+  | _ -> "Canopy"
 
 let root cache =
-  match KeyMap.find_config_opt cache [".config";"root"] with
-    None -> "http://localhost"
-  | Some r -> r
+  match KeyMap.find_opt cache @@ entry "root" with
+  | Some (`Config r) -> r
+  | _ -> "http://localhost"

--- a/canopy_content.ml
+++ b/canopy_content.ml
@@ -44,8 +44,8 @@ let to_tyxml = function
 let to_tyxml_listing_entry = function
   | Markdown m -> Canopy_article.to_tyxml_listing_entry m
 
-let to_atom = function
-  | Markdown m -> Canopy_article.to_atom m
+let to_atom cache = function
+  | Markdown m -> Canopy_article.to_atom cache m
 
 let find_tag tagname = function
   | Markdown m ->

--- a/canopy_content.ml
+++ b/canopy_content.ml
@@ -63,7 +63,7 @@ let updated = function
 
 let tags content_map =
   let module S = Set.Make(String) in
-  let s = KeyMap.fold (
+  let s = KeyMap.fold_articles (
       fun _k v s -> match v with
         | Markdown m ->
           let s' = S.of_list m.Canopy_article.tags in

--- a/canopy_content.ml
+++ b/canopy_content.ml
@@ -17,7 +17,7 @@ let meta_assoc str =
       let value = Re_str.matched_group 2 meta in
       key, value)
 
-let of_string ~uri ~created ~updated ~content =
+let of_string ~base_uuid ~uri ~created ~updated ~content =
   let splitted_content = Re_str.bounded_split (Re_str.regexp "---") content 2 in
   match splitted_content with
   | [raw_meta;raw_content] ->
@@ -28,7 +28,7 @@ let of_string ~uri ~created ~updated ~content =
           match assoc_opt "content" meta with
           | Some "markdown"
           | None ->
-            Canopy_article.of_string meta uri created updated raw_content
+            Canopy_article.of_string base_uuid meta uri created updated raw_content
             |> map_opt (fun article -> Ok (Markdown article)) (Error "Error while parsing article")
           | Some _ -> Unknown
         end

--- a/canopy_dispatch.ml
+++ b/canopy_dispatch.ml
@@ -109,10 +109,9 @@ module Make (S: Cohttp_lwt.Server)
     let callback = match dispatch with
       | `Redirect fn ->
         (fun _ request _ ->
-           let req = Cohttp.Request.uri request in
-           let uri = fn req in
-           Log.info (fun f -> f "redirecting to %s" (Uri.to_string uri)) ;
-           moved_permanently uri)
+           let redirect = fn (Cohttp.Request.uri request) in
+           Log.info (fun f -> f "redirecting to %s" (Uri.to_string redirect)) ;
+           moved_permanently redirect)
       | `Dispatch (headers, store, atom, content) ->
         (fun _ request _ ->
            let uri = Cohttp.Request.uri request in

--- a/canopy_dispatch.ml
+++ b/canopy_dispatch.ml
@@ -3,18 +3,21 @@ open Lwt.Infix
 type store_ops = {
   subkeys : string list -> string list list Lwt.t ;
   value : string list -> string option Lwt.t ;
-  update : unit -> string list Lwt.t ;
+  update : unit -> unit Lwt.t ;
   last_commit : unit -> Ptime.t Lwt.t ;
 }
 
-module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE)
+module Make (S: Cohttp_lwt.Server)
 = struct
+
+  let src = Logs.Src.create "canopy-dispatch" ~doc:"Canopy dispatch logger"
+  module Log = (val Logs.src_log src : Logs.LOG)
 
   let moved_permanently uri =
     let headers = Cohttp.Header.init_with "location" (Uri.to_string uri) in
     S.respond ~headers ~status:`Moved_permanently ~body:`Empty ()
 
-  let rec dispatcher headers console store atom cache uri etag updated =
+  let rec dispatcher headers store atom cache uri etag updated =
     let open Canopy_utils in
     let respond_not_found () =
       S.respond_string ~headers ~status:`Not_found ~body:"Not found" ()
@@ -31,24 +34,20 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE)
       let body = Canopy_templates.main ~cache:(!cache) ~content ~title ~keys in
       let headers = html_headers headers updated in
       respond_if_modified ~headers ~body ~updated
-    and respond_update = function
-      | [] -> S.respond_string ~headers ~status:`OK ~body:"" ()
-      | errors ->
-        let body = List.fold_left (fun a b -> a ^ "\n" ^ b) "" errors in
-        S.respond_string ~headers ~status:`Bad_request ~body ()
+    and respond_update () = S.respond_string ~headers ~status:`OK ~body:"" ()
     in
     match Re_str.split (Re_str.regexp "/") (Uri.pct_decode uri) with
     | [] ->
       let index_page = Canopy_config.index_page !cache in
-      dispatcher headers console store atom cache index_page etag updated
+      dispatcher headers store atom cache index_page etag updated
     | "atom" :: [] ->
       atom () >>= fun body ->
       store.last_commit () >>= fun updated ->
       let headers = atom_headers headers updated in
       respond_if_modified ~headers ~body ~updated
     | uri::[] when uri = Canopy_config.push_hook_path () ->
-      store.update () >>= fun l ->
-      respond_update l
+      store.update () >>= fun () ->
+      respond_update ()
     | "tags"::[] -> (
       let tags = Canopy_content.tags !cache in
       let content = Canopy_article.to_tyxml_tags tags in
@@ -102,24 +101,24 @@ module Make (S: Cohttp_lwt.Server) (C: V1_LWT.CONSOLE)
           respond_if_modified ~headers ~body ~updated
       end
 
-  let create console dispatch =
+  let create dispatch =
     let conn_closed (_, conn_id) =
       let cid = Cohttp.Connection.to_string conn_id in
-      C.log console (Printf.sprintf "conn %s closed" cid)
+      Log.debug (fun f -> f "conn %s closed" cid)
     in
     let callback = match dispatch with
       | `Redirect fn ->
         (fun _ request _ ->
            let req = Cohttp.Request.uri request in
            let uri = fn req in
-           C.log_s console (Printf.sprintf "redirecting to %s" (Uri.to_string uri)) >>= fun () ->
+           Log.info (fun f -> f "redirecting to %s" (Uri.to_string uri)) ;
            moved_permanently uri)
       | `Dispatch (headers, store, atom, content, time) ->
         (fun _ request _ ->
            let uri = Cohttp.Request.uri request in
            let etag = Cohttp.Header.get Cohttp.Request.(request.headers) "if-none-match" in
-           C.log_s console (Printf.sprintf "request %s" (Uri.to_string uri)) >>= fun () ->
-           dispatcher headers console store atom content (Uri.path uri) etag time)
+           Log.info (fun f -> f "request %s" (Uri.to_string uri)) ;
+           dispatcher headers store atom content (Uri.path uri) etag time)
     in
     S.make ~callback ~conn_closed ()
 

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -42,9 +42,10 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
     let open Canopy_utils in
     let cache = ref (KeyMap.empty) in
     Store.pull console >>= fun () ->
-    Store.fill_cache cache >>= fun l ->
+    Store.base_uuid () >>= fun uuid ->
+    Store.fill_cache uuid cache >>= fun l ->
     let update_atom, atom =
-      Canopy_syndic.atom Store.last_commit_date cache
+      Canopy_syndic.atom uuid Store.last_commit_date cache
     in
     let store_ops = {
       Canopy_dispatch.subkeys = Store.get_subkeys ;
@@ -52,7 +53,7 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
       update =
         (fun () ->
            Store.pull console >>= fun () ->
-           Store.fill_cache cache >>= fun res ->
+           Store.fill_cache uuid cache >>= fun res ->
            update_atom () >|= fun () ->
            res);
       last_commit = Store.last_commit_date ;

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -80,13 +80,9 @@ module Main (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (CLOCK: V
        and port = Canopy_config.port ()
        in
        S.listen_tcpv4 stack ~port http ;
-       Log.info (fun f ->
-           let redirect =
-             let req = Uri.of_string "http://127.0.0.1" in
-             (* TODO: use own hostname instead of 127.0.0.1 once we have that *)
-             Uri.to_string (redir req)
-           in
-           f "HTTP server listening on port %d (redirecting to %s)" port redirect) ;
+       Log.info (fun f -> f "HTTP server listening on port %d, \
+                             redirecting to https service on port %d"
+                    port tls_port) ;
        tls_init keys >|= fun tls_conf ->
        let hdr = Cohttp.Header.init_with
            "Strict-Transport-Security" "max-age=31536000" (* in seconds, roughly a year *)

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -1,7 +1,7 @@
 open Lwt
 open V1_LWT
 
-module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (CLOCK: V1.CLOCK) (KEYS: KV_RO) = struct
+module Main (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (CLOCK: V1.CLOCK) (KEYS: KV_RO) = struct
 
   module TCP  = S.TCPV4
   module TLS  = Tls_mirage.Make (TCP)
@@ -10,25 +10,35 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
   module HTTP  = Cohttp_mirage.Server(TCP)
   module HTTPS = Cohttp_mirage.Server(TLS)
 
-  module D  = Canopy_dispatch.Make(HTTP)(C)
-  module DS = Canopy_dispatch.Make(HTTPS)(C)
+  module D  = Canopy_dispatch.Make(HTTP)
+  module DS = Canopy_dispatch.Make(HTTPS)
 
-  let log c fmt = Printf.ksprintf (C.log c) fmt
+  let src = Logs.Src.create "canopy-main" ~doc:"Canopy main logger"
+  module Log = (val Logs.src_log src : Logs.LOG)
 
-  let with_tls c cfg tcp f =
+  let with_tls cfg tcp f =
     let peer, port = TCP.get_dest tcp in
-    let log str = log c "[%s:%d] %s" (Ipaddr.V4.to_string peer) port str in
-    let with_tls_server k = TLS.server_of_flow cfg tcp >>= k in
-    with_tls_server @@ function
-    | `Error _ -> log "TLS failed"; TCP.close tcp
-    | `Ok tls  -> log "TLS ok"; f tls >>= fun () ->TLS.close tls
-    | `Eof     -> log "TLS eof"; TCP.close tcp
+    TLS.server_of_flow cfg tcp >>= function
+    | `Error e ->
+      Log.warn (fun f -> f "%s:%d TLS failed %s" (Ipaddr.V4.to_string peer) port (TLS.error_message e)) ;
+      TCP.close tcp
+    | `Ok tls ->
+      Log.info (fun f -> f "%s:%d TLS ok" (Ipaddr.V4.to_string peer) port);
+      f tls >>= fun () -> TLS.close tls
+    | `Eof ->
+      Log.info (fun f -> f "%s:%d TLS eof" (Ipaddr.V4.to_string peer) port);
+      TCP.close tcp
+
+  let with_tcp tcp f =
+    let peer, port = TCP.get_dest tcp in
+    Log.info (fun f -> f "%s:%d TCP established" (Ipaddr.V4.to_string peer) port);
+    f tcp >>= fun () -> TCP.close tcp
 
   let tls_init kv =
     X509.certificate kv `Default >|= fun cert ->
     Tls.Config.server ~certificates:(`Single cert) ()
 
-  let start console stack resolver conduit _clock keys _ =
+  let start stack resolver conduit _clock keys _ =
     let started = match Ptime.of_float_s (CLOCK.time ()) with
       | None -> invalid_arg ("Ptime.of_float_s")
       | Some t -> t
@@ -38,12 +48,11 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
         let v _ = Lwt.return_some (resolver, conduit)
       end : Irmin_mirage.CONTEXT)
     in
-    let module Store = Canopy_store.Store(C)(Context)(Inflator) in
-    let open Canopy_utils in
-    let cache = ref (KeyMap.empty) in
-    Store.pull console >>= fun () ->
+    let module Store = Canopy_store.Store(Context)(Inflator) in
+    Store.pull () >>= fun () ->
     Store.base_uuid () >>= fun uuid ->
-    Store.fill_cache uuid cache >>= fun l ->
+    Store.fill_cache uuid >>= fun new_cache ->
+    let cache = ref (new_cache) in
     let update_atom, atom =
       Canopy_syndic.atom uuid Store.last_commit_date cache
     in
@@ -52,14 +61,13 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
       value = Store.get_key ;
       update =
         (fun () ->
-           Store.pull console >>= fun () ->
-           Store.fill_cache uuid cache >>= fun res ->
-           update_atom () >|= fun () ->
-           res);
+           Store.pull () >>= fun () ->
+           Store.fill_cache uuid >>= fun new_cache ->
+           cache := new_cache ;
+           update_atom ());
       last_commit = Store.last_commit_date ;
     } in
     update_atom () >>= fun () ->
-    Lwt_list.iter_p (C.log_s console) l >>= fun () ->
     let disp hdr =
       `Dispatch (hdr, store_ops, atom, cache, started)
     in
@@ -73,36 +81,35 @@ module Main  (C: CONSOLE) (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirag
          in
          Uri.with_port https port
        in
-       let http = HTTP.listen (D.create console (`Redirect redir))
+       let http_callback = HTTP.listen (D.create (`Redirect redir)) in
+       let http flow = with_tcp flow http_callback
        and port = Canopy_config.port ()
        in
        S.listen_tcpv4 stack ~port http ;
-       C.log_s console
-         (let redirect =
-            let req = Uri.of_string "http://127.0.0.1" in
-            (* TODO: use own hostname instead of 127.0.0.1 once we have that *)
-            Uri.to_string (redir req)
-          in
-          Printf.sprintf "HTTP server listening on port %d (redirecting to %s)"
-            port redirect
-         ) >>= fun () ->
-       tls_init keys >>= fun tls_conf ->
+       Log.info (fun f ->
+           let redirect =
+             let req = Uri.of_string "http://127.0.0.1" in
+             (* TODO: use own hostname instead of 127.0.0.1 once we have that *)
+             Uri.to_string (redir req)
+           in
+           f "HTTP server listening on port %d (redirecting to %s)" port redirect) ;
+       tls_init keys >|= fun tls_conf ->
        let hdr = Cohttp.Header.init_with
            "Strict-Transport-Security" "max-age=31536000" (* in seconds, roughly a year *)
        in
-       let callback = HTTPS.listen (DS.create console (disp hdr)) in
-       let https flow = with_tls console tls_conf flow callback in
+       let callback = HTTPS.listen (DS.create (disp hdr)) in
+       let https flow = with_tls tls_conf flow callback in
        S.listen_tcpv4 stack ~port:tls_port https ;
-       C.log_s console
-         (Printf.sprintf "HTTPS server listening on port %d" tls_port)
+       Log.info (fun f -> f "HTTPS server listening on port %d" tls_port)
      | None ->
        let hdr = Cohttp.Header.init () in
-       let http = HTTP.listen (D.create console (disp hdr))
+       let http_callback = HTTP.listen (D.create (disp hdr)) in
+       let http flow = with_tcp flow http_callback
        and port = Canopy_config.port ()
        in
        S.listen_tcpv4 stack ~port http ;
-       C.log_s console
-         (Printf.sprintf "HTTP server listening on port %d" port)
+       Log.info (fun f -> f "HTTP server listening on port %d" port) ;
+       Lwt.return_unit
     ) >>= fun () ->
     S.listen stack
 end

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -39,10 +39,6 @@ module Main (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (CLOCK: V
     Tls.Config.server ~certificates:(`Single cert) ()
 
   let start stack resolver conduit _clock keys _ =
-    let started = match Ptime.of_float_s (CLOCK.time ()) with
-      | None -> invalid_arg ("Ptime.of_float_s")
-      | Some t -> t
-    in
     let module Context =
       ( struct
         let v _ = Lwt.return_some (resolver, conduit)
@@ -68,9 +64,7 @@ module Main (S: STACKV4) (RES: Resolver_lwt.S) (CON: Conduit_mirage.S) (CLOCK: V
       last_commit = Store.last_commit_date ;
     } in
     update_atom () >>= fun () ->
-    let disp hdr =
-      `Dispatch (hdr, store_ops, atom, cache, started)
-    in
+    let disp hdr = `Dispatch (hdr, store_ops, atom, cache) in
     (match Canopy_config.tls_port () with
      | Some tls_port ->
        let redir uri =

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -47,7 +47,7 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
   let base_uuid () =
     get_key [".config" ; "uuid"] >|= function
     | None -> invalid_arg ".config/uuid is required in the remote git repository"
-    | Some n -> n
+    | Some n -> String.trim n
 
   let pull console =
     new_task () >>= fun t ->
@@ -99,7 +99,7 @@ module Store (C: CONSOLE) (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = st
         (cache := KeyMap.add key (`Raw content) !cache;
          Lwt.return acc)
       | `Config ->
-        (cache := KeyMap.add key (`Config content) !cache;
+        (cache := KeyMap.add key (`Config (String.trim content)) !cache;
          Lwt.return acc)
       | `Article ->
         let uri = String.concat "/" key in

--- a/canopy_store.ml
+++ b/canopy_store.ml
@@ -95,7 +95,7 @@ module Store (CTX: Irmin_mirage.CONTEXT) (INFL: Git.Inflate.S) = struct
       value () >>= fun content ->
       date_updated_created key >|= fun (updated, created) ->
       match key_type key with
-      | `Static -> KeyMap.add key (`Raw content) cache
+      | `Static -> KeyMap.add key (`Raw (content, updated)) cache
       | `Config -> KeyMap.add key (`Config (String.trim content)) cache
       | `Article ->
         let uri = String.concat "/" key in

--- a/canopy_syndic.ml
+++ b/canopy_syndic.ml
@@ -3,7 +3,7 @@ open Lwt.Infix
 open Canopy_utils
 open Canopy_config
 
-let atom last_commit_date content_cache =
+let atom uuid last_commit_date content_cache =
   let cache = ref None in
   let update_atom () =
     let l = KeyMap.fold_articles (fun _ x acc -> x :: acc) !content_cache []
@@ -13,7 +13,7 @@ let atom last_commit_date content_cache =
     let ns_prefix _ = Some "" in
     last_commit_date () >|= fun updated ->
     Syndic.Atom.feed
-      ~id:(Uri.of_string ("urn:uuid:" ^ uuid !content_cache))
+      ~id:(Uri.of_string ("urn:uuid:" ^ uuid))
       ~title:(Syndic.Atom.Text (blog_name !content_cache): Syndic.Atom.text_construct)
       ~updated
       ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string (root !content_cache ^ "/atom"))]

--- a/canopy_syndic.ml
+++ b/canopy_syndic.ml
@@ -3,20 +3,20 @@ open Lwt.Infix
 open Canopy_utils
 open Canopy_config
 
-let atom config last_commit_date content_cache =
+let atom last_commit_date content_cache =
   let cache = ref None in
   let update_atom () =
     let l = KeyMap.fold_articles (fun _ x acc -> x :: acc) !content_cache []
             |> List.sort Canopy_content.compare
             |> resize 10 in
-    let entries = List.map Canopy_content.to_atom l in
+    let entries = List.map (Canopy_content.to_atom !content_cache) l in
     let ns_prefix _ = Some "" in
     last_commit_date () >|= fun updated ->
     Syndic.Atom.feed
-      ~id:(Uri.of_string ("urn:uuid:" ^ config.uuid))
-      ~title:(Syndic.Atom.Text config.blog_name : Syndic.Atom.text_construct)
+      ~id:(Uri.of_string ("urn:uuid:" ^ uuid !content_cache))
+      ~title:(Syndic.Atom.Text (blog_name !content_cache): Syndic.Atom.text_construct)
       ~updated
-      ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string (config.root ^ "/atom"))]
+      ~links:[Syndic.Atom.link ~rel:Syndic.Atom.Self (Uri.of_string (root !content_cache ^ "/atom"))]
       entries
     |> fun feed -> Syndic.Atom.to_xml feed
     |> fun x -> Syndic.XML.to_string ~ns_prefix x

--- a/canopy_syndic.ml
+++ b/canopy_syndic.ml
@@ -6,7 +6,7 @@ open Canopy_config
 let atom config last_commit_date content_cache =
   let cache = ref None in
   let update_atom () =
-    let l = KeyMap.fold (fun _ x acc -> x :: acc) !content_cache []
+    let l = KeyMap.fold_articles (fun _ x acc -> x :: acc) !content_cache []
             |> List.sort Canopy_content.compare
             |> resize 10 in
     let entries = List.map Canopy_content.to_atom l in

--- a/canopy_templates.ml
+++ b/canopy_templates.ml
@@ -22,9 +22,9 @@ let links keys =
 		       ) keys |> List.sort_uniq (Pervasives.compare) in
   let format_link link =
     li [ a ~a:[a_href ("/" ^ link)] [span [pcdata link]]] in
- List.map format_link paths
+  List.map format_link paths
 
-let main ~config ~content ~title ~keys =
+let main ~cache ~content ~title ~keys =
   let links = links keys in
   let page =
     html
@@ -52,7 +52,7 @@ let main ~config ~content ~title ~keys =
                    span ~a:[a_class ["icon-bar"]][];
                    span ~a:[a_class ["icon-bar"]][]
                  ];
-                 a ~a:[a_class ["navbar-brand"]; a_href ("/" ^ config.index_page)][pcdata config.blog_name]
+                 a ~a:[a_class ["navbar-brand"]; a_href ("/" ^ index_page cache)][pcdata (blog_name cache)]
                ];
                div ~a:[a_class ["collapse navbar-collapse collapse"]] [
                  ul ~a:[a_class ["nav navbar-nav navbar-right"]] links

--- a/canopy_utils.ml
+++ b/canopy_utils.ml
@@ -62,11 +62,6 @@ module KeyMap = struct
     match find_opt m k with
     | Some (`Article a) -> Some a
     | _ -> None
-
-  let find_config_opt m k =
-    match find_opt m k with
-    | Some (`Config a) -> Some a
-    | _ -> None
 end
 
 let add_etag_header time headers =

--- a/canopy_utils.ml
+++ b/canopy_utils.ml
@@ -62,6 +62,11 @@ module KeyMap = struct
     match find_opt m k with
     | Some (`Article a) -> Some a
     | _ -> None
+
+  let find_config_opt m k =
+    match find_opt m k with
+    | Some (`Config a) -> Some a
+    | _ -> None
 end
 
 let add_etag_header time headers =

--- a/canopy_utils.ml
+++ b/canopy_utils.ml
@@ -49,9 +49,19 @@ module KeyMap = struct
   module M = Map.Make(KeyOrd)
   include M
 
+  let fold_articles f =
+    M.fold (fun k v acc -> match v with
+        | `Article a -> f k a acc
+        | _ -> acc)
+
   let find_opt m k =
     try Some (M.find k m) with
     | Not_found -> None
+
+  let find_article_opt m k =
+    match find_opt m k with
+    | Some (`Article a) -> Some a
+    | _ -> None
 end
 
 let add_etag_header time headers =

--- a/config.ml
+++ b/config.ml
@@ -34,6 +34,7 @@ let libraries = [
     "tyxml";
     "syndic";
     "uuidm";
+    "logs";
   ]
 
 let packages = [
@@ -53,6 +54,7 @@ let packages = [
     "syndic";
     "magic-mime";
     "uuidm";
+    "logs"
   ]
 
 
@@ -78,8 +80,7 @@ let () =
       ~keys
       ~packages
       "Canopy_main.Main"
-      (console @-> stackv4 @-> resolver @-> conduit @-> clock @-> kv_ro @-> job)
-    $ default_console
+      (stackv4 @-> resolver @-> conduit @-> clock @-> kv_ro @-> job)
     $ stack
     $ resolver_dns stack
     $ conduit_direct ~tls:true stack

--- a/config.ml
+++ b/config.ml
@@ -2,30 +2,6 @@ open Mirage
 
 (* Command-line options *)
 
-let root_k =
-  let doc = Key.Arg.info ~doc:"Blog URL" ["root"] in
-  Key.(create "root" Arg.(opt string "http://localhost" doc))
-
-let uuid_k =
-  let doc = Key.Arg.info ~doc:"UUID used as atom feed id." ["u"; "uuid"] in
-  Key.(create "uuid" Arg.(required string doc))
-
-let index_k =
-  let doc = Key.Arg.info ~doc:"Index file name in remote." ["i"; "index"] in
-  Key.(create "index" Arg.(opt string "Index" doc))
-
-let tls_port_k =
-  let doc = Key.Arg.info ~doc:"Enable TLS (using keys in `tls/`) on given port." ["tls"] in
-  Key.(create "tls_port" Arg.(opt (some int) None doc))
-
-let name_k =
-  let doc = Key.Arg.info ~doc:"Blog name." ["n"; "name"] in
-  Key.(create "name" Arg.(opt string "Canopy" doc))
-
-let port_k =
-  let doc = Key.Arg.info ~doc:"Socket port." ["p"; "port"] in
-  Key.(create "port" Arg.(opt int 8080 doc))
-
 let push_hook_k =
   let doc = Key.Arg.info ~doc:"GitHub push hook." ["hook"] in
   Key.(create "push_hook" Arg.(opt string "push" doc))
@@ -81,14 +57,8 @@ let stack =
 
 let () =
   let keys = Key.([
-      abstract index_k;
-      abstract name_k;
-      abstract port_k;
       abstract push_hook_k;
       abstract remote_k;
-      abstract tls_port_k;
-      abstract uuid_k;
-      abstract root_k;
     ])
   in
   register "canopy" [

--- a/config.ml
+++ b/config.ml
@@ -13,6 +13,14 @@ let remote_k =
       ["r"; "remote"] in
   Key.(create "remote" Arg.(opt string "https://github.com/Engil/__blog.git" doc))
 
+let port_k =
+  let doc = Key.Arg.info ~doc:"Socket port." ["p"; "port"] in
+  Key.(create "port" Arg.(opt int 8080 doc))
+
+let tls_port_k =
+  let doc = Key.Arg.info ~doc:"Enable TLS (using keys in `tls/`) on given port." ["tls"] in
+  Key.(create "tls_port" Arg.(opt (some int) None doc))
+
 (* Dependencies *)
 
 let libraries = [
@@ -59,6 +67,8 @@ let () =
   let keys = Key.([
       abstract push_hook_k;
       abstract remote_k;
+      abstract port_k;
+      abstract tls_port_k;
     ])
   in
   register "canopy" [

--- a/populate.sh
+++ b/populate.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+TARGET=$1
+
+if [ -x `which npm` ]; then
+    if [ -d $1 ]; then
+        mkdir -p $1/static/css $1/static/js
+        npm install
+        browserify assets/js/main.js -o $1/static/js/canopy.js
+        lessc assets/less/style.less $1/static/css/style.css --source-map-map-inline --strict-imports
+        cp node_modules/bootstrap/dist/css/bootstrap.min.css $1/static/css/bootstrap.min.css
+        cp node_modules/highlight.js/styles/grayscale.css $1/static/css/highlight.css
+        echo "now go to $1 and git add static && git commit -m . && git push"
+    else
+        echo "please run as 'populate.sh data_repository'"
+    fi
+else
+    echo "npm not found, please unpack assets/assets_generated.tar.gz to your data repository"
+fi


### PR DESCRIPTION
- static assets and config in git: (on top of #64, see also https://github.com/hannesm/Canopy/pull/2 for details)
- fix the store a bit: `fill_cache` now returns a `KeyMap.t` which is stored in a global ref locally in `Canopy_main`
- use `Logs` instead of console for logging
- no more `CONSOLE` needed \o/
