### PR TITLE
inflator: avoid unused var warning; install Node.js 6 using NodeSource repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ocaml/opam:debian-stable_ocaml-4.03.0
 MAINTAINER canopy
 ENV OPAMYES 1
 RUN sudo apt-get update
-RUN sudo apt-get -yy install npm
-RUN sudo ln -s `which nodejs` /usr/bin/node
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+RUN sudo apt-get install -yy nodejs
 RUN sudo npm install -g less browserify
 RUN cd /home/opam/opam-repository && git pull && opam update
 ADD package.json README.md config.ml /src/

--- a/inflator.ml
+++ b/inflator.ml
@@ -25,8 +25,8 @@ let deflate ?(level = 4) buff =
      size_buffer)
     (Decompress.Deflate.default ~proof:Decompress.B.proof_bytes level)
   |> function
-     | Ok t -> Cstruct.of_string @@ Buffer.contents res
-     | Error exn -> failwith "Deflate.deflate"
+     | Ok _t -> Cstruct.of_string @@ Buffer.contents res
+     | Error _exn -> failwith "Deflate.deflate"
 
 let inflate ?output_size orig =
   let res = Buffer.create (match output_size with Some len -> len | None -> size_buffer) in
@@ -50,7 +50,7 @@ let inflate ?output_size orig =
 
       Buffer.add_subbytes res output_buffer 0 (used_out t);
       loop ~refill:(used_in t) (flush 0 size_buffer t)
-    | `Error (t, exn) -> None
+    | `Error (_t, _exn) -> None
     | `End t ->
       Mstruct.shift orig (used_in t - rest);
 


### PR DESCRIPTION
When compiling, there used to be a few of these warnings:

```
File "inflator.ml", line 53, characters 14-15:
Warning 27: unused variable t.

File "inflator.ml", line 53, characters 17-20:
Warning 27: unused variable exn.
```

This PR avoids those.

---

To get to a **green build**, this PR also switches to install Node.js using the [installation instructions from the Node.js homepage](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).