### PR TITLE
Avoid warning: use Cohttp_lwt.S.Server

### DIFF
--- a/canopy_dispatch.ml
+++ b/canopy_dispatch.ml
@@ -7,7 +7,7 @@ type store_ops = {
   last_commit : unit -> Ptime.t Lwt.t ;
 }
 
-module Make (S: Cohttp_lwt.Server) = struct
+module Make (S: Cohttp_lwt.S.Server) = struct
 
   let src = Logs.Src.create "canopy-dispatch" ~doc:"Canopy dispatch logger"
   module Log = (val Logs.src_log src : Logs.LOG)


### PR DESCRIPTION
This avoids a warning when using `Cohttp_lwt.Server`

```
File "canopy_dispatch.ml", line 10, characters 16-33:
Warning 3: deprecated: Cohttp_lwt.Server
Use Cohttp_lwt.S.Server
```