### PR TITLE
Proposed implementation for feature request author url (this fixes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The file syntax of articles is just plain markdown, everything should be support
 ---
 title: A blog entry
 author: Me
+author_url: www.an_optional_link_that_wraps_the_author.com
 abstract: A simple line telling what this article is all about, will be displayed in listing pages. (optional)
 ---
 article content

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The file syntax of articles is just plain markdown, everything should be support
 ---
 title: A blog entry
 author: Me
-author_url: www.an_optional_link_that_wraps_the_author.com
+author_url: http://www.an_optional_link_that_wraps_the_author.com
 abstract: A simple line telling what this article is all about, will be displayed in listing pages. (optional)
 ---
 article content


### PR DESCRIPTION
This feature implementation is in order to have an optional author_url metadata field, which (if present) renders a hyperlink around the author name.