### PR TITLE
use newly release cohttp-mirage

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -30,7 +30,7 @@ let packages = [
   package ~min:"0.5" "decompress";
   package ~min:"1.0.0" "irmin";
   package "irmin-mirage";
-  package "mirage-http";
+  package "cohttp-mirage";
   package "mirage-flow";
   package ~sublibs:["mirage"] "tls";
   package "re";


### PR DESCRIPTION
now that irmin and git are bumped to work with cohttp-1.0 (and OCaml 4.06.0), we can safely depend on cohttp-mirage (used to be mirage-http) and get compilation of Canopy on 4.06.0! :)