### PR TITLE
update to conduit 4.0.0

### DIFF
--- a/canopy_dispatch.ml
+++ b/canopy_dispatch.ml
@@ -7,7 +7,7 @@ type store_ops = {
   last_commit : unit -> Ptime.t Lwt.t ;
 }
 
-module Make (S: Cohttp_lwt.S.Server) = struct
+module Make (S: Cohttp_mirage.Server.S) = struct
 
   let src = Logs.Src.create "canopy-dispatch" ~doc:"Canopy dispatch logger"
   module Log = (val Logs.src_log src : Logs.LOG)

--- a/canopy_main.ml
+++ b/canopy_main.ml
@@ -1,9 +1,7 @@
 open Lwt.Infix
 
-module Main (S: Mirage_stack.V4V6) (_: sig end) (Http : Cohttp_mirage.Server.S) (CLOCK: Mirage_clock.PCLOCK) (KEYS: Mirage_kv.RO) = struct
+module Main (_: sig end) (Http : Cohttp_mirage.Server.S) (CLOCK: Mirage_clock.PCLOCK) (KEYS: Mirage_kv.RO) = struct
 
-  module TCP  = S.TCP
-  module TLS  = Tls_mirage.Make (TCP)
   module X509 = Tls_mirage.X509 (KEYS) (CLOCK)
 
   module D  = Canopy_dispatch.Make(Http)
@@ -17,7 +15,7 @@ module Main (S: Mirage_stack.V4V6) (_: sig end) (Http : Cohttp_mirage.Server.S) 
 
   module Store = Canopy_store
 
-  let start stack ctx http _clock keys =
+  let start ctx http _clock keys =
     Store.pull ~ctx >>= fun () ->
     Store.base_uuid () >>= fun uuid ->
     Store.fill_cache uuid >>= fun new_cache ->

--- a/config.ml
+++ b/config.ml
@@ -2,7 +2,7 @@ open Mirage
 
 
 (* boilerplate from https://github.com/mirage/ocaml-git.git unikernel/config.ml
-   (commit #2220ba7fe749d228a52e52f25f3761575269a98a) *)
+   (commit #3bfcf215f959b71580e5c0b655700bb9484aee8c) *)
 type mimic = Mimic
 
 let mimic = typ Mimic
@@ -32,7 +32,7 @@ let mimic_tcp_conf =
   let packages = [ package "git-mirage" ~sublibs:[ "tcp" ] ] in
   impl @@ object
        inherit base_configurable
-       method ty = stackv4 @-> mimic
+       method ty = stackv4v6 @-> mimic
        method module_name = "Git_mirage_tcp.Make"
        method! packages = Key.pure packages
        method name = "tcp_ctx"
@@ -43,7 +43,7 @@ let mimic_tcp_conf =
          | _ -> assert false
      end
 
-let mimic_tcp_impl stackv4 = mimic_tcp_conf $ stackv4
+let mimic_tcp_impl stackv4v6 = mimic_tcp_conf $ stackv4v6
 
 let mimic_ssh_conf ~kind ~seed ~auth =
   let seed = Key.abstract seed in
@@ -51,7 +51,7 @@ let mimic_ssh_conf ~kind ~seed ~auth =
   let packages = [ package "git-mirage" ~sublibs:[ "ssh" ] ] in
   impl @@ object
        inherit base_configurable
-       method ty = stackv4 @-> mimic @-> mclock @-> mimic
+       method ty = stackv4v6 @-> mimic @-> mclock @-> mimic
        method! keys = [ seed; auth; ]
        method module_name = "Git_mirage_ssh.Make"
        method! packages = Key.pure packages
@@ -77,9 +77,9 @@ let mimic_ssh_conf ~kind ~seed ~auth =
          | _ -> assert false
      end
 
-let mimic_ssh_impl ~kind ~seed ~auth stackv4 mimic_git mclock =
+let mimic_ssh_impl ~kind ~seed ~auth stackv4v6 mimic_git mclock =
   mimic_ssh_conf ~kind ~seed ~auth
-  $ stackv4
+  $ stackv4v6
   $ mimic_git
   $ mclock
 
@@ -89,7 +89,7 @@ let mimic_dns_conf =
   let packages = [ package "git-mirage" ~sublibs:[ "dns" ] ] in
   impl @@ object
        inherit base_configurable
-       method ty = random @-> mclock @-> time @-> stackv4 @-> mimic @-> mimic
+       method ty = random @-> mclock @-> time @-> stackv4v6 @-> mimic @-> mimic
        method module_name = "Git_mirage_dns.Make"
        method! packages = Key.pure packages
        method name = "dns_ctx"
@@ -105,9 +105,48 @@ let mimic_dns_conf =
          | _ -> assert false
      end
 
-let mimic_dns_impl random mclock time stackv4 mimic_tcp =
-  mimic_dns_conf $ random $ mclock $ time $ stackv4 $ mimic_tcp
+let mimic_dns_impl random mclock time stackv4v6 mimic_tcp =
+  mimic_dns_conf $ random $ mclock $ time $ stackv4v6 $ mimic_tcp
 
+type paf = Paf
+let paf = typ Paf
+
+let paf_conf () =
+  let packages = [ package "paf" ~sublibs:[ "mirage" ] ] in
+  impl @@ object
+    inherit base_configurable
+    method ty = time @-> stackv4v6 @-> paf
+    method module_name = "Paf_mirage.Make"
+    method! packages = Key.pure packages
+    method name = "paf"
+  end
+
+let paf_impl time stackv4v6 = paf_conf () $ time $ stackv4v6
+
+let mimic_paf_conf () =
+  let packages = [ package "git-paf" ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = time @-> pclock @-> stackv4v6 @-> paf @-> mimic @-> mimic
+       method module_name = "Git_paf.Make"
+       method! packages = Key.pure packages
+       method name = "paf_ctx"
+       method! connect _ modname = function
+         | [ _; _; _; _; tcp_ctx; ] ->
+             Fmt.str
+               {ocaml|let paf_ctx00 = Mimic.merge %s %s.ctx in
+                      Lwt.return paf_ctx00|ocaml}
+               tcp_ctx modname
+         | _ -> assert false
+     end
+
+let mimic_paf_impl time pclock stackv4v6 paf mimic_tcp =
+  mimic_paf_conf ()
+  $ time
+  $ pclock
+  $ stackv4v6
+  $ paf
+  $ mimic_tcp
 (* --- end of copied code --- *)
 
 (* Command-line options *)
@@ -146,11 +185,10 @@ let packages = [
   package ~min:"4.0.0" "tyxml";
   package "ptime";
   package ~min:"0.5" "decompress";
-  package ~min:"2.0.0" "irmin";
-  package ~min:"2.0.0" "irmin-mirage";
-  package ~min:"2.0.0" "irmin-mirage-git";
-  package ~min:"3.3.1" "git-mirage";
-  package "git-cohttp-mirage";
+  package ~min:"2.6.0" "irmin";
+  package ~min:"2.6.0" "irmin-mirage";
+  package ~min:"2.6.0" "irmin-mirage-git";
+  package ~min:"3.4.0" "git-mirage";
   package "cohttp-mirage";
   package "mirage-flow";
   package "tls-mirage";
@@ -164,17 +202,19 @@ let packages = [
 
 
 (* Network stack *)
-let stack = generic_stackv4 default_network
+let stack = generic_stackv4v6 default_network
 
-let mimic_impl ~kind ~seed ~authenticator stackv4 random mclock time =
-  let mtcp = mimic_tcp_impl stackv4 in
-  let mdns = mimic_dns_impl random mclock time stackv4 mtcp in
-  let mssh = mimic_ssh_impl ~kind ~seed ~auth:authenticator stackv4 mtcp mclock in
-  merge mssh mdns
+let mimic_impl ~kind ~seed ~authenticator stackv4v6 random mclock pclock time paf =
+  let mtcp = mimic_tcp_impl stackv4v6 in
+  let mdns = mimic_dns_impl random mclock time stackv4v6 mtcp in
+  let mssh = mimic_ssh_impl ~kind ~seed ~auth:authenticator stackv4v6 mtcp mclock in
+  let mpaf = mimic_paf_impl time pclock stackv4v6 paf mtcp in
+  merge mpaf (merge mssh mdns)
 
 let mimic_impl =
   mimic_impl ~kind:`Rsa ~seed:ssh_seed ~authenticator:ssh_authenticator stack
-    default_random default_monotonic_clock default_time
+    default_random default_monotonic_clock default_posix_clock default_time
+    (paf_impl default_time stack)
 
 let () =
   let keys = Key.([
@@ -189,11 +229,10 @@ let () =
       ~keys
       ~packages
       "Canopy_main.Main"
-      (stackv4 @-> mimic @-> resolver @-> conduit @-> pclock @-> kv_ro @-> job)
+      (stackv4v6 @-> mimic @-> http @-> pclock @-> kv_ro @-> job)
     $ stack
     $ mimic_impl
-    $ resolver_dns stack
-    $ conduit_direct ~tls:true stack
+    $ cohttp_server (conduit_direct ~tls:true stack)
     $ default_posix_clock
     $ crunch "tls"
   ]

--- a/config.ml
+++ b/config.ml
@@ -229,8 +229,7 @@ let () =
       ~keys
       ~packages
       "Canopy_main.Main"
-      (stackv4v6 @-> mimic @-> http @-> pclock @-> kv_ro @-> job)
-    $ stack
+      (mimic @-> http @-> pclock @-> kv_ro @-> job)
     $ mimic_impl
     $ cohttp_server (conduit_direct ~tls:true stack)
     $ default_posix_clock


### PR DESCRIPTION
This is an attempt (where the resulting unikernel works) to port it to conduit 4.0.0.

There are some drawbacks: due to API changes, I'm completely lost how a `with_tcp` and `with_tls` could be reconstructed (per-session wrapper that emit a log message for each connection, including the IP address) -- maybe @samoht or @dinosaure know of a better path here?

The resulting unikernel supports both IPv4 and IPv6 \o/